### PR TITLE
Cleanups context usage

### DIFF
--- a/internal/newsclient/headlines/headlines.go
+++ b/internal/newsclient/headlines/headlines.go
@@ -56,7 +56,6 @@ type Params struct {
 // It implements the newsclient.Client interface.
 type Client struct {
 	newsclient.ServiceEndpoint
-	ContextOrigin context.Context
 	RequestOrigin *http.Request
 }
 
@@ -106,7 +105,7 @@ func (c Client) Get(ctxOrigin context.Context, reqOrigin *http.Request, params n
 	req.URL.RawQuery = q
 
 	// Dispatch request to news API.
-	resp, err := c.DispatchRequest(req)
+	resp, err := c.DispatchRequest(ctx, req)
 	if err != nil {
 		return nil, &httperror.HTTPError{
 			Code:       http.StatusBadRequest,
@@ -123,7 +122,7 @@ func (c Client) Get(ctxOrigin context.Context, reqOrigin *http.Request, params n
 //
 // It encodes and return a news.ErrorResponse when an error is encountered.
 // Returns news.Response otherwise for successful requests.
-func (c Client) DispatchRequest(r *http.Request) (*news.Response, error) {
+func (c Client) DispatchRequest(_ context.Context, r *http.Request) (*news.Response, error) {
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return nil, err

--- a/internal/newsclient/headlines/headlines_test.go
+++ b/internal/newsclient/headlines/headlines_test.go
@@ -18,7 +18,6 @@ import (
 // FakeClient mocks a Client interface.
 type FakeClient struct {
 	newsclient.ServiceEndpoint
-	ContextOrigin context.Context
 	RequestOrigin *http.Request
 	IsValid       bool
 }
@@ -60,7 +59,7 @@ func (f FakeClient) Get(_ context.Context, _ *http.Request, p Params) (*news.Res
 	return nil, errors.New("some error")
 }
 
-func (f FakeClient) DispatchRequest(r *http.Request) (*news.Response, error) {
+func (f FakeClient) DispatchRequest(_ context.Context, r *http.Request) (*news.Response, error) {
 	if f.IsValid {
 		return &news.Response{
 			Status:       "200",
@@ -288,17 +287,17 @@ func TestDispatchRequest(t *testing.T) {
 
 	r, err := http.NewRequest("GET", server.URL, nil)
 	if err != nil {
-		t.Fatalf("DispatchRequest(_): error creating a new request: %v", err)
+		t.Fatalf("DispatchRequest(_, _): error creating a new request: %v", err)
 	}
 
-	got, err := Client{}.DispatchRequest(r)
+	got, err := Client{}.DispatchRequest(context.Background(), r)
 	if err != nil {
-		t.Errorf("DispatchRequest(_): want (%v, nil), got (%v, %v)", want, got, err)
+		t.Errorf("DispatchRequest(_, _): want (%v, nil), got (%v, %v)", want, got, err)
 	}
 
 	if diff := pretty.Compare(got, want); diff != "" {
 		desc := "returns a news.Response and nil error"
-		t.Errorf("%s: DispatchRequest(_) diff: (-got +want)\n%s", desc, diff)
+		t.Errorf("%s: DispatchRequest(_, _) diff: (-got +want)\n%s", desc, diff)
 	}
 }
 
@@ -314,17 +313,17 @@ func TestDispatchRequestErrors(t *testing.T) {
 
 	r, err := http.NewRequest("GET", server.URL, nil)
 	if err != nil {
-		t.Fatalf("DispatchRequest(_): error creating a new request: %v", err)
+		t.Fatalf("DispatchRequest(_, _): error creating a new request: %v", err)
 	}
 
-	got, err := Client{}.DispatchRequest(r)
+	got, err := Client{}.DispatchRequest(context.Background(), r)
 	if err == nil {
-		t.Errorf("DispatchRequest(_): want (nil, error), got (%v, %v)", got, err)
+		t.Errorf("DispatchRequest(_, _): want (nil, error), got (%v, %v)", got, err)
 	}
 
 	if diff := pretty.Compare(err, want); diff != "" {
 		desc := "returns a news.ErrorResponse when error is encountered"
-		t.Errorf("%s: DispatchRequest(_) diff: (-got +want)\n%s", desc, diff)
+		t.Errorf("%s: DispatchRequest(_, _) diff: (-got +want)\n%s", desc, diff)
 	}
 }
 

--- a/internal/newsclient/list/list.go
+++ b/internal/newsclient/list/list.go
@@ -139,7 +139,7 @@ func (c Client) Get(ctxOrigin context.Context, reqOrigin *http.Request, params n
 //
 // It encodes and return a news.ErrorResponse when an error is encountered.
 // Returns news.Response otherwise for successful requests.
-func (c Client) DispatchRequest(_ ctx.Context, r *http.Request) (*news.Response, error) {
+func (c Client) DispatchRequest(_ context.Context, r *http.Request) (*news.Response, error) {
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return nil, err

--- a/internal/newsclient/list/list.go
+++ b/internal/newsclient/list/list.go
@@ -70,7 +70,6 @@ type Params struct {
 // It implements the newsclient.Client interface.
 type Client struct {
 	newsclient.ServiceEndpoint
-	ContextOrigin context.Context
 	RequestOrigin *http.Request
 }
 
@@ -123,7 +122,7 @@ func (c Client) Get(ctxOrigin context.Context, reqOrigin *http.Request, params n
 	req.URL.RawQuery = q
 
 	// Dispatch request to newsapi.
-	resp, err := c.DispatchRequest(req)
+	resp, err := c.DispatchRequest(ctx, req)
 	if err != nil {
 		return nil, &httperror.HTTPError{
 			Code:       http.StatusBadRequest,
@@ -140,7 +139,7 @@ func (c Client) Get(ctxOrigin context.Context, reqOrigin *http.Request, params n
 //
 // It encodes and return a news.ErrorResponse when an error is encountered.
 // Returns news.Response otherwise for successful requests.
-func (c Client) DispatchRequest(r *http.Request) (*news.Response, error) {
+func (c Client) DispatchRequest(_ ctx.Context, r *http.Request) (*news.Response, error) {
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return nil, err

--- a/internal/newsclient/list/list_test.go
+++ b/internal/newsclient/list/list_test.go
@@ -290,7 +290,7 @@ func TestDispatchRequest(t *testing.T) {
 		t.Fatalf("DispatchRequest(_): error creating a new request: %v", err)
 	}
 
-	got, err := Client{}.DispatchRequest(r)
+	got, err := Client{}.DispatchRequest(context.Background(), r)
 	if err != nil {
 		t.Errorf("DispatchRequest(_): want (%v, nil), got (%v, %v)", want, got, err)
 	}
@@ -316,7 +316,7 @@ func TestDispatchRequestErrors(t *testing.T) {
 		t.Fatalf("DispatchRequest(_): error creating a new request: %v", err)
 	}
 
-	got, err := Client{}.DispatchRequest(r)
+	got, err := Client{}.DispatchRequest(context.Background(), r)
 	if err == nil {
 		t.Errorf("DispatchRequest(_): want (nil, error), got (%v, %v)", got, err)
 	}

--- a/internal/newsclient/list/list_test.go
+++ b/internal/newsclient/list/list_test.go
@@ -18,7 +18,6 @@ import (
 // FakeClient mocks a Client interface.
 type FakeClient struct {
 	newsclient.ServiceEndpoint
-	ContextOrigin context.Context
 	RequestOrigin *http.Request
 	IsValid       bool
 }

--- a/internal/newsclient/newsclient.go
+++ b/internal/newsclient/newsclient.go
@@ -30,7 +30,7 @@ type Params interface {
 // Client describes an HTTP news client.
 type Client interface {
 	Get(context.Context, *http.Request, Params) (*news.Response, error)
-	DispatchRequest(*http.Request) (*news.Response, error)
+	DispatchRequest(context.Context, *http.Request) (*news.Response, error)
 }
 
 // ServiceEndpoint wraps a URL in where a request should be dispatched to.

--- a/web/handler/news_test.go
+++ b/web/handler/news_test.go
@@ -34,7 +34,6 @@ func (fp FakeParams) Encode() (string, error) {
 // FakeClient mocks a newsclient.Client interface.
 type FakeClient struct {
 	newsclient.ServiceEndpoint
-	ContextOrigin context.Context
 	RequestOrigin *http.Request
 	IsValid       bool
 }
@@ -75,7 +74,7 @@ func (f FakeClient) Get(_ context.Context, _ *http.Request, p newsclient.Params)
 	return nil, errors.New("some error")
 }
 
-func (f FakeClient) DispatchRequest(r *http.Request) (*news.Response, error) {
+func (f FakeClient) DispatchRequest(_ context.Context, r *http.Request) (*news.Response, error) {
 	if f.IsValid {
 		return &news.Response{
 			Status:       "200",
@@ -107,7 +106,6 @@ func setupFakeClient(t *testing.T, conf config) FakeClient {
 		ServiceEndpoint: newsclient.ServiceEndpoint{
 			URL: "test-url",
 		},
-		ContextOrigin: conf.ctx,
 		RequestOrigin: conf.req,
 		IsValid:       conf.isValid,
 	}


### PR DESCRIPTION
Contexts are meant to be passed around as the first argument to a function and never to be encapsulated in a struct.